### PR TITLE
border-divider Tailwind hotfix

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "canvas-embed",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "canvas-embed",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
@@ -54,7 +54,7 @@
         "prettier": "^3.1.1",
         "prettier-plugin-tailwindcss": "^0.5.9",
         "style-loader": "^3.3.3",
-        "tailwindcss": "^3.3.6",
+        "tailwindcss": "^3.4.0",
         "tailwindcss-themer": "^4.0.0",
         "ts-loader": "^9.5.1",
         "typescript": "^5.3.3",
@@ -12319,9 +12319,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.6.tgz",
-      "integrity": "sha512-AKjF7qbbLvLaPieoKeTjG1+FyNZT6KaJMJPFeQyLfIp7l82ggH1fbHJSsYIvnbTFQOlkh+gBYpyby5GT1LIdLw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.0.tgz",
+      "integrity": "sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/react/package.json
+++ b/react/package.json
@@ -60,7 +60,7 @@
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.5.9",
     "style-loader": "^3.3.3",
-    "tailwindcss": "^3.3.6",
+    "tailwindcss": "^3.4.0",
     "tailwindcss-themer": "^4.0.0",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.3",

--- a/react/src/Canvas.tsx
+++ b/react/src/Canvas.tsx
@@ -10,7 +10,7 @@ type CanvasInnerProps = {
 export const CanvasInner = ({ canvasData, dataHash }: CanvasInnerProps) => {
     const { elementOrder, elements } = canvasData;
     return (
-        <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+        <div className="canvas-container flex flex-1 flex-col gap-4 overflow-y-auto">
             <Filters canvasData={canvasData} />
             <section className="mt-5 flex flex-col gap-8">
                 {elementOrder.element_order.map((elementIds, index) => (

--- a/react/styles/index.less
+++ b/react/styles/index.less
@@ -20,3 +20,9 @@ body {
 
     overscroll-behavior-x: contain;
 }
+
+.canvas-container {   
+    .border-divider {
+        border-color: rgba(var(--colors-divider), var(--tw-border-opacity));
+    }
+}


### PR DESCRIPTION
This fixes the border color on spreadsheets

Hacky and terrible, but I don't know why Tailwind is showing the `border-color' property for `.border-divider` as:

```
border-color: rgb(var(--colors-divider) / var(--tw-border-opacity));
```

When it's showing as the following on our live site:

```
border-color: rgba(var(--colors-divider), var(--tw-border-opacity))
```

This is what's causing the difference in color.

Reverting Tailwind to the same older version used on the live site didn't fix it.

Just a hotfix for now until the solution is found.