### PR TITLE
Fixed loading screen for React module

### DIFF
--- a/react/src/Canvas.tsx
+++ b/react/src/Canvas.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import { Filters } from './filter/Filters';
 import { CanvasElement } from './CanvasElement';
-import { Spinner } from './Spinner';
 import { EmbedResponse } from './types/EmbedResponse';
 
 type CanvasInnerProps = {
     canvasData: EmbedResponse;
     dataHash?: string;
-    loading: boolean;
     downloadCsv?: (elementId: string, title: string) => void;
 };
-export const CanvasInner = ({ canvasData, dataHash, loading, downloadCsv }: CanvasInnerProps) => {
+export const CanvasInner = ({ canvasData, dataHash, downloadCsv }: CanvasInnerProps) => {
     const { elementOrder, elements, theme } = canvasData;
     return (
         <div className="flex flex-1 flex-col overflow-y-auto gap-4">
             <div className="flex items-center gap-1">
                 <Filters canvasData={canvasData} />
-                {loading && <Spinner />}
             </div>
             <section className="flex flex-col gap-8">
                 {elementOrder.element_order.map((elementIds, index) => (

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -118,7 +118,7 @@ export const Canvas: React.FC<CanvasProps> = ({ canvasId, authToken, host: hostO
     if (canvasData) {
         return (
             <TailwindWrapper>
-                <CanvasInner canvasData={canvasData} dataHash={dataHash} loading={loading} downloadCsv={downloadCsv} />
+                <CanvasInner canvasData={canvasData} dataHash={dataHash} downloadCsv={downloadCsv} />
             </TailwindWrapper>
         );
     }
@@ -135,7 +135,7 @@ export const Canvas: React.FC<CanvasProps> = ({ canvasId, authToken, host: hostO
 export const CanvasSnapshot: React.FC<CanvasSnapshotProps> = ({ canvasData }: CanvasSnapshotProps) => {
     return (
         <TailwindWrapper>
-            <CanvasInner canvasData={canvasData} loading={false} />
+            <CanvasInner canvasData={canvasData} />
         </TailwindWrapper>
     );
 };

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -115,14 +115,6 @@ export const Canvas: React.FC<CanvasProps> = ({ canvasId, authToken, host: hostO
         );
     }
 
-    if (loading) {
-      return (
-        <TailwindWrapper>
-          <Spinner />
-        </TailwindWrapper>
-      )
-    };
-
     if (canvasData) {
         return (
             <TailwindWrapper>
@@ -130,6 +122,14 @@ export const Canvas: React.FC<CanvasProps> = ({ canvasId, authToken, host: hostO
             </TailwindWrapper>
         );
     }
+
+    if (loading) {
+        return (
+          <TailwindWrapper>
+            <Spinner />
+          </TailwindWrapper>
+        )
+      };
 };
 
 export const CanvasSnapshot: React.FC<CanvasSnapshotProps> = ({ canvasData }: CanvasSnapshotProps) => {

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -7,6 +7,7 @@ import useCanvasState from './state/useCanvasState';
 import isEmpty from 'lodash/isEmpty';
 import { buildUrl, convertFilterParams } from './util/util';
 import { EmbedResponse } from './types/EmbedResponse';
+import { Spinner } from './Spinner';
 
 type CanvasProps = {
     canvasId: string;
@@ -42,8 +43,8 @@ export const Canvas: React.FC<CanvasProps> = ({ canvasId, authToken, host: hostO
             },
         )
             .then(async (res) => {
-                setLoading(false);
                 const canvasData = await res.json();
+                setLoading(false);
                 if (!res.ok) {
                     console.error(`Error getting canvas data: ${JSON.stringify(canvasData)}`);
                     setCanvasData(null);
@@ -113,6 +114,15 @@ export const Canvas: React.FC<CanvasProps> = ({ canvasId, authToken, host: hostO
             </TailwindWrapper>
         );
     }
+
+    if (loading) {
+      return (
+        <TailwindWrapper>
+          <Spinner />
+        </TailwindWrapper>
+      )
+    };
+
     if (canvasData) {
         return (
             <TailwindWrapper>


### PR DESCRIPTION
When a dashboard was being pulled into a React project via the <Canvas /> component, the browser showed a blank screen instead of a loading icon. 

This PR ensures that the loading icon (<Spinner /> component) is displayed while waiting for the data to render. 